### PR TITLE
Add a WebAssembly.Memory property to Context

### DIFF
--- a/src/wasi_snapshot_preview1.ts
+++ b/src/wasi_snapshot_preview1.ts
@@ -212,14 +212,18 @@ function syscall(target: Function): Function {
 }
 
 export interface ContextOptions {
+  memory?: WebAssembly.Memory;
 }
 
 export type ContextExports = Record<string, Function>;
 
 export default class Context {
+  memory: WebAssembly.Memory;
   exports: ContextExports;
 
   constructor(options: ContextOptions) {
+    this.memory = options.memory!;
+
     this.exports = {
       args_get: syscall((
         argv_ptr: number,


### PR DESCRIPTION
This adds a WebAsssembly.Memory property to the Context with then name memory which is the memory which will be considered the imported memory in accordance with the ABI.