### PR TITLE
Flatten build script

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -1,27 +1,25 @@
-export default async function build() {
-  try {
-    await Deno.mkdir("lib");
-  } catch (err) {
-    // no-op
-  }
-
-  const [diagnostics, records] = await Deno.compile(
-    "src/wasi_snapshot_preview1.ts",
-    undefined,
-    {
-      outDir: "lib",
-    },
-  );
-
-  if (diagnostics) {
-    throw Error(diagnostics.join(" "));
-  }
-
-  for (const [filepath, source] of Object.entries(records)) {
-    await Deno.writeTextFile(filepath, source);
-  }
+try {
+  await Deno.mkdir("lib");
+} catch (err) {
+  // no-op
 }
 
-if (import.meta.main) {
-  build();
+const [diagnostics, records] = await Deno.compile(
+  "src/wasi_snapshot_preview1.ts",
+  undefined,
+  {
+    outDir: "lib",
+  },
+);
+
+if (diagnostics) {
+  for (const diagnostic of diagnostics) {
+    console.error(diagnostics);
+  }
+
+  Deno.exit(1);
+}
+
+for (const [filepath, source] of Object.entries(records)) {
+  await Deno.writeTextFile(filepath, source);
 }


### PR DESCRIPTION
This flattens the build script to be a standalone script without any exports.