### PR TITLE
Fix test runner memory

### DIFF
--- a/test.ts
+++ b/test.ts
@@ -291,6 +291,7 @@ async function serveRunner(manifest: unknown, ignore: string[]) {
 	  wasi_snapshot_preview1: context.exports,
 	});
 
+	context.memory = instance.exports.memory;
 	instance.exports._start();
 	await pass();
       } catch (error) {


### PR DESCRIPTION
The context used in the test runner has no memory assigned to it.
This fixes that.