### PR TITLE
Stub out fd_prestat_get and fd_prestat_dirname

### DIFF
--- a/src/wasi_snapshot_preview1.ts
+++ b/src/wasi_snapshot_preview1.ts
@@ -356,7 +356,7 @@ export default class Context {
         fd: number,
         buf_out: number,
       ): number => {
-        return ERRNO_NOSYS;
+        return ERRNO_BADF;
       }),
 
       fd_prestat_dir_name: syscall((
@@ -364,7 +364,7 @@ export default class Context {
         path_ptr: number,
         path_len: number,
       ): number => {
-        return ERRNO_NOSYS;
+        return ERRNO_BADF;
       }),
 
       fd_pwrite: syscall((


### PR DESCRIPTION
This stubs out fd_prestat_get and fd_prestat_dirname so that they do not interefere with the startup process which will abort if these return errno::nosys.