### PR TITLE
Implement environ_get and environ_sizes_get

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This module provides an implementation of the WebAssembly System Interface for W
 
 - [ ] args_get
 - [ ] args_sizes_get
-- [ ] environ_get
-- [ ] environ_sizes_get
+- [x] environ_get
+- [x] environ_sizes_get
 - [ ] clock_res_get
 - [ ] clock_time_get
 - [ ] fd_advise

--- a/test.ts
+++ b/test.ts
@@ -13,8 +13,6 @@ import {
 const ignore = [
   "tests/std_env_args_none.wasm",
   "tests/std_env_args_some.wasm",
-  "tests/std_env_vars_none.wasm",
-  "tests/std_env_vars_some.wasm",
   "tests/std_fs_create_dir_absolute.wasm",
   "tests/std_fs_create_dir_relative.wasm",
   "tests/std_fs_file_create_absolute.wasm",
@@ -282,6 +280,7 @@ async function serveRunner(manifest: unknown, ignore: string[]) {
 
       try {
 	const context = new Context({
+          env: options.env,
 	});
 
 	const request = await fetch(pathname);


### PR DESCRIPTION
This implements environ_get and environ_sizes_get by mapping them to an object containing environment variables on the context.