### PR TITLE
Update deno to 1.3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
 
     - name: Set up Deno
       uses: denolib/setup-deno@v2
+      with:
+        deno-version: 1.3.2
 
     - name: Build
       run: |
@@ -38,6 +40,8 @@ jobs:
 
     - name: Set up Deno
       uses: denolib/setup-deno@v2
+      with:
+        deno-version: 1.3.2
 
     - name: Lint
       run: |


### PR DESCRIPTION
This pins deno at version 1.3.3 and std at 0.68.0 to avoid any unexpected suprises and breakage in std when a new release rolls out.