### PR TITLE
Fix duplication of build diagnostic messages

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -12,7 +12,7 @@ const [diagnostics, records] = await Deno.compile(
 
 if (diagnostics) {
   for (const diagnostic of diagnostics) {
-    console.error(diagnostics);
+    console.error(diagnostic);
   }
 
   Deno.exit(1);


### PR DESCRIPTION
There's a minor typo that is causing the entire diagnostics array to be dumped on every diagnostic error.

This fixes the offending mishap.