### PR TITLE
Implement clock_res_get

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This module provides an implementation of the WebAssembly System Interface for W
 - [x] args_sizes_get
 - [x] environ_get
 - [x] environ_sizes_get
-- [ ] clock_res_get
+- [x] clock_res_get
 - [ ] clock_time_get
 - [ ] fd_advise
 - [ ] fd_allocate

--- a/src/wasi_snapshot_preview1.ts
+++ b/src/wasi_snapshot_preview1.ts
@@ -319,7 +319,33 @@ export default class Context {
         id: number,
         resolution_out: number,
       ): number => {
-        return ERRNO_NOSYS;
+        const memory_view = new DataView(this.memory.buffer);
+
+        switch (id) {
+          case CLOCKID_REALTIME: {
+            const resolution = BigInt(1e6);
+
+            memory_view.setBigUint64(
+              resolution_out,
+              resolution,
+              true,
+            );
+            break;
+          }
+
+          case CLOCKID_MONOTONIC:
+          case CLOCKID_PROCESS_CPUTIME_ID:
+          case CLOCKID_THREAD_CPUTIME_ID: {
+            const resolution = BigInt(1e3);
+            memory_view.setBigUint64(resolution_out, resolution, true);
+            break;
+          }
+
+          default:
+            return ERRNO_INVAL;
+        }
+
+        return ERRNO_SUCCESS;
       }),
 
       clock_time_get: syscall((

--- a/test.ts
+++ b/test.ts
@@ -29,6 +29,7 @@ const options = parse(Deno.args, {
 const tests = [
   "tests/std_env_args.wasm",
   "tests/std_env_vars.wasm",
+  "tests/wasi_clock_res_get.wasm",
   "tests/wasi_random_get.wasm",
 ];
 


### PR DESCRIPTION
This implements clock_res_get yielding millisecond precision for realtime clocks and microsecond precision.