### PR TITLE
Implement clock_time_get

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This module provides an implementation of the WebAssembly System Interface for W
 - [x] environ_get
 - [x] environ_sizes_get
 - [x] clock_res_get
-- [ ] clock_time_get
+- [x] clock_time_get
 - [ ] fd_advise
 - [ ] fd_allocate
 - [ ] fd_close

--- a/src/wasi_snapshot_preview1.ts
+++ b/src/wasi_snapshot_preview1.ts
@@ -353,7 +353,33 @@ export default class Context {
         precision: bigint,
         time_out: number,
       ): number => {
-        return ERRNO_NOSYS;
+        const memory_view = new DataView(this.memory.buffer);
+
+        switch (id) {
+          case CLOCKID_REALTIME: {
+            const time = BigInt(Date.now()) * BigInt(1e6);
+            memory_view.setBigUint64(time_out, time, true);
+            break;
+          }
+
+          case CLOCKID_MONOTONIC:
+          case CLOCKID_PROCESS_CPUTIME_ID:
+          case CLOCKID_THREAD_CPUTIME_ID: {
+            const t = performance.now();
+            const s = Math.trunc(t);
+            const ms = Math.floor((t - s) * 1e3);
+
+            const time = BigInt(s) * BigInt(1e9) + BigInt(ms) * BigInt(1e6);
+
+            memory_view.setBigUint64(time_out, time, true);
+            break;
+          }
+
+          default:
+            return ERRNO_INVAL;
+        }
+
+        return ERRNO_SUCCESS;
       }),
 
       fd_advise: syscall((

--- a/test.ts
+++ b/test.ts
@@ -30,6 +30,7 @@ const tests = [
   "tests/std_env_args.wasm",
   "tests/std_env_vars.wasm",
   "tests/wasi_clock_res_get.wasm",
+  "tests/wasi_clock_time_get.wasm",
   "tests/wasi_random_get.wasm",
 ];
 


### PR DESCRIPTION
This implements clock_time_get with millisecond precision for the realtime clock and microsecond precision for the other clocks.