### PR TITLE
Make stderr option in ContextOptions optional

### DIFF
--- a/src/wasi_snapshot_preview1.ts
+++ b/src/wasi_snapshot_preview1.ts
@@ -232,7 +232,7 @@ export interface ContextOptions {
   args?: string[];
   env?: { [key: string]: string | undefined };
   stdout?: Writer;
-  stderr: Writer;
+  stderr?: Writer;
   memory?: WebAssembly.Memory;
 }
 


### PR DESCRIPTION
This makes the stderr option in ContextOptions actually optional.