### PR TITLE
Extract index into a string literal

### DIFF
--- a/test.ts
+++ b/test.ts
@@ -151,6 +151,18 @@ window.onload = async function() {
   }
 };`;
 
+const index = `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title></title>
+</head>
+<body>
+<script type="module">${module}</script>
+</body>
+</html>`;
+
 const server = serve({ port: 8080 });
 
 const browser = browse({
@@ -176,7 +188,7 @@ for await (const request of server) {
     switch (request.url) {
       case "/":
       case "/index.html": {
-        await request.respond(await serveIndex());
+        await request.respond({ body: index });
         break;
       }
 
@@ -258,22 +270,4 @@ function print(text: string, noNewLine = false) {
   if (!noNewLine) {
     Deno.stdout.writeSync(encoder.encode("\n"));
   }
-}
-
-async function serveIndex() {
-  const body = `
-  <!DOCTYPE html>
-  <html lang="en">
-  <head>
-  <meta charset="utf-8">
-  <title></title>
-  </head>
-  <body>
-  <script type="module">${module}</script>
-  </body>
-  </html>`;
-
-  return {
-    body,
-  };
 }


### PR DESCRIPTION
This extracts the index request handler into a string literal and serves it directly as it is not doing anything dynamic there is no need for it to be a function call.